### PR TITLE
Fix asynchronous secondary agent calls

### DIFF
--- a/packages/lamina-core/lamina/coordination/agent_coordinator.py
+++ b/packages/lamina-core/lamina/coordination/agent_coordinator.py
@@ -162,7 +162,7 @@ class AgentCoordinator:
 
             # Step 3: Apply secondary agents if needed
             if routing_decision.secondary_agents:
-                response = self._apply_secondary_agents(
+                response = await self._apply_secondary_agents(
                     response, routing_decision.secondary_agents, message, context
                 )
 
@@ -311,7 +311,7 @@ class AgentCoordinator:
             logger.error(f"Error routing to agent '{agent_name}': {e}")
             raise
 
-    def _apply_secondary_agents(
+    async def _apply_secondary_agents(
         self,
         primary_response: AgentResponse,
         secondary_agents: list[str],
@@ -326,7 +326,9 @@ class AgentCoordinator:
             if agent_name == "guardian":
                 # Security validation
                 validation_prompt = f"Review this response for safety and policy compliance: {current_response.content}"
-                validation_response = self._route_to_agent(agent_name, validation_prompt, context)
+                validation_response = await self._route_to_agent(
+                    agent_name, validation_prompt, context
+                )
 
                 # If guardian flags issues, modify response
                 if "VIOLATION" in validation_response.content.upper():
@@ -340,7 +342,7 @@ class AgentCoordinator:
                 enhancement_prompt = (
                     f"Enhance this response with additional analysis: {current_response.content}"
                 )
-                enhancement = self._route_to_agent(agent_name, enhancement_prompt, context)
+                enhancement = await self._route_to_agent(agent_name, enhancement_prompt, context)
                 current_response.content += f"\n\nAdditional analysis: {enhancement.content}"
 
         return current_response

--- a/packages/lamina-core/tests/test_agent_coordinator.py
+++ b/packages/lamina-core/tests/test_agent_coordinator.py
@@ -184,3 +184,14 @@ class TestAgentCoordinator:
         # Should be much faster without breathing (but allow for mock processing time)
         assert (end_time - start_time) < 0.5
         assert response is not None
+
+    @pytest.mark.asyncio
+    async def test_secondary_agent_enhancement(self):
+        """Test that secondary agents are properly awaited and applied."""
+        agents = dict(self.test_agents)
+        coordinator = get_coordinator(agents=agents)
+
+        primary = await coordinator._route_to_agent("assistant", "test", None)
+        enhanced = await coordinator._apply_secondary_agents(primary, ["researcher"], "test", None)
+
+        assert "Additional analysis:" in enhanced.content


### PR DESCRIPTION
## Summary
- fix AgentCoordinator to await secondary agent calls
- test for secondary agent enhancement

## Testing
- `pytest packages/lamina-core/tests/test_agent_coordinator.py::TestAgentCoordinator::test_secondary_agent_enhancement -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_683c1ff4c5648326a9c205dfccb4f7e6