### PR TITLE
docs: add GitHub Pages documentation site with MkDocs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,57 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'requirements-docs.txt'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements-docs.txt
+
+      - name: Build documentation
+        run: |
+          mkdocs build --strict
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: 'site'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![License: MPL-2.0](https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg)](https://opensource.org/licenses/MPL-2.0)
 
+> ⚠️ **PRE-ALPHA SOFTWARE WARNING**
+> 
+> Lamina OS is currently in pre-alpha development and is NOT suitable for production use. The framework is under active development with rapidly changing APIs, incomplete features, and potential security vulnerabilities. Use for research, experimentation, and development only. Do not deploy in production environments or use with sensitive data.
+
 Lamina OS is a symbolic operating system framework that enables developers to build **non-human agents of presence** with **breath-based modulation** — mindful, deliberate operations that prioritize attunement over speed. Instead of traditional reactive AI systems, Lamina agents operate through rhythmic constraint application and symbolic reasoning.
 
 ## 🌱 Core Philosophy

--- a/docs/.pages
+++ b/docs/.pages
@@ -1,0 +1,9 @@
+nav:
+  - index.md
+  - guides
+  - technical
+  - philosophy
+  - adrs
+  - high-council
+  - releases
+  - pir

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,331 @@
+# Lamina OS Roadmap
+
+**Updated:** January 6, 2025  
+**Status:** Based on ADR Implementation Assessment  
+
+## Executive Summary
+
+Lamina OS has achieved exceptional architectural maturity with a sophisticated breath-first AI development framework. The infrastructure is production-ready, core agent architecture is operational, and governance processes are well-established. **The focus is on internal framework development and maturation toward eventual v1.0.0 readiness.**
+
+## v1.0.0 Target Features
+
+### **Core Features Required for v1.0.0**
+
+1. **Hierarchical Agentic Memory (A-MEM)**
+   - Persistent agent memory across sessions and interactions
+   - Hierarchical organization (short-term, working, long-term memory)
+   - Context-aware retrieval and intelligent memory management
+   - Shared memory spaces for agent collaboration
+
+2. **Integrated Chat Loop**
+   - Core conversation management integrating memory and model inference
+   - Multi-turn conversation handling with context preservation
+   - Breath-first conversation flow with deliberate pauses
+   - Dynamic context window management and conversation compression
+
+3. **Multi-Agent Interaction Experiments**
+   - Framework for setting up agent-to-agent interaction scenarios
+   - Experiment configuration, orchestration, and analysis tools
+   - Inter-agent communication protocols and message passing
+   - Reproducible experiment isolation and logging capabilities
+
+4. **Vow System Implementation**
+   - Ethical constraint enforcement architecture
+   - Vow definition, validation, and runtime enforcement
+   - Integration with agent essence and behavioral boundaries
+   - Violation detection and remediation mechanisms
+
+5. **Room Transition System**
+   - Spatial context management for agent interactions
+   - Room-based agent containment and transitions
+   - Context preservation during room changes
+   - Multi-room agent coordination and communication
+
+These features will transform Lamina OS from an agent foundation into a complete presence-aware AI system with persistent memory, ethical constraints, spatial awareness, and multi-agent coordination capabilities.
+
+## Current State Assessment
+
+### ✅ **Completed Foundations (13/19 ADRs)**
+- **Agent Architecture** (ADR-0019): Complete implementation with essence-based configuration
+- **Infrastructure** (ADR-0020): Enterprise-grade Kubernetes deployment with service mesh
+- **Testing Strategy** (ADR-0010): Comprehensive three-tier testing with real AI models
+- **Monorepo Architecture** (ADR-0002): Full workspace implementation
+- **Governance** (ADR-0001, 0016): ADR process and template enforcement operational
+- **Environment Management** (ADR-0011): Multi-tier configuration system
+- **CLI Architecture** (ADR-0012): Three-tier CLI with plugin architecture
+
+### 🚧 **Partial Implementation (3 ADRs)**
+- **Open Source Roadmap** (ADR-0003): Framework implementation needs completion
+- **Documentation Strategy** (ADR-0004): Internal documentation needs organization and completeness
+- **Terminology Framework** (ADR-0007): Glossary exists, enforcement and consistency needed
+
+### 📋 **Awaiting Implementation (1 ADR)**
+- **Training Aligned Model** (ADR-0015): Future enhancement, not critical for v1.0
+
+### ⚠️ **Pending Approval (2 ADRs)**
+- **Agent Architecture** (ADR-0019): Implementation complete, High Council review needed
+- **Terminology Framework** (ADR-0007): Needs status update to ACCEPTED
+
+## Roadmap Phases
+
+---
+
+## 🎯 **Phase 1: Core v1.0.0 Features** 
+**Timeline:** 8-12 weeks  
+**Priority:** HIGH - Essential for v1.0.0 release
+
+### **Hierarchical Agentic Memory (A-MEM)**
+- [ ] **A-MEM Integration**
+  - Implement hierarchical memory architecture
+  - Agent memory persistence across sessions
+  - Context-aware memory retrieval and storage
+  - Memory sharing between coordinated agents
+  
+- [ ] **Memory System Architecture**
+  - Define memory hierarchy (short-term, working, long-term)
+  - Implement memory compression and pruning
+  - Add memory search and query capabilities
+  - Integration with agent essence and constraints
+
+### **Core Chat Loop Implementation**
+- [ ] **Integrated Chat System**
+  - Core chat loop integrating memory and model
+  - Multi-turn conversation management
+  - Context preservation across interactions
+  - Breath-first conversation flow with deliberate pauses
+  
+- [ ] **Memory-Model Integration**
+  - Seamless memory retrieval during conversations
+  - Dynamic context window management
+  - Conversation history compression and storage
+  - Agent state persistence between turns
+
+### **Multi-Agent Interaction Experiments**
+- [ ] **Experiment Framework**
+  - Define multi-turn agent-to-agent interaction patterns
+  - Experiment configuration and orchestration
+  - Agent coordination protocols and message passing
+  - Interaction logging and analysis tools
+  
+- [ ] **Agent Communication**
+  - Inter-agent messaging and coordination
+  - Shared memory spaces for agent collaboration
+  - Conflict resolution and consensus mechanisms
+  - Experiment isolation and reproducibility
+
+### **Vow System Implementation**
+- [ ] **Ethical Constraint Architecture**
+  - Core vow definition and specification system
+  - Runtime vow enforcement and validation
+  - Violation detection and response mechanisms
+  - Integration with agent essence and behavioral boundaries
+  
+- [ ] **Constraint Engine**
+  - Real-time constraint checking during agent interactions
+  - Vow inheritance and composition patterns
+  - Performance optimization for constraint evaluation
+  - Debugging and introspection tools for vow violations
+
+### **Room Transition System**
+- [ ] **Spatial Context Management**
+  - Room definition and configuration system
+  - Agent containment and spatial awareness
+  - Context preservation during room transitions
+  - Room-based memory and state management
+  
+- [ ] **Multi-Room Coordination**
+  - Inter-room communication protocols
+  - Agent movement and transition handling
+  - Shared resources and cross-room interactions
+  - Room hierarchy and access control
+
+### **ADR-0003: Supporting Framework Features**
+- [ ] **Enhanced Agent Architecture**
+  - Agent lifecycle management with memory, vows, and rooms
+  - Sanctuary configuration for all core systems
+  - Comprehensive agent coordination for multi-agent scenarios
+
+### **ADR-0004: Internal Documentation Excellence**
+- [ ] **Technical Documentation**
+  - Complete API documentation
+  - Architecture decision documentation
+  - Integration guides between components
+  
+- [ ] **Development Guides**
+  - Agent development workflow
+  - Infrastructure deployment procedures
+  - Testing and debugging guides
+
+- [ ] **Reference Materials**
+  - Complete configuration reference
+  - Troubleshooting documentation
+  - Performance optimization guides
+
+### **ADR-0007: Terminology Framework Enforcement**
+- [ ] **Corpus Migration**
+  - Complete terminology alignment across all documentation
+  - Implement validation in CI/CD pipeline
+  - Update all code comments and docstrings
+
+- [ ] **Enforcement Mechanisms**
+  - Automated terminology checking
+  - Glossary integration in documentation
+  - Contributor education materials
+
+---
+
+## 🔧 **Phase 2: Developer Experience & Documentation**
+**Timeline:** 2-4 weeks  
+**Priority:** MEDIUM - Supporting v1.0.0 development
+
+### **ADR-0012: CLI UX Enhancement**
+- [ ] **Poetic Command Evolution**
+  - Implement natural language command patterns
+  - Add breath-first interaction flows
+  - Enhance command discovery and help
+
+### **ADR-0013: Workshop Structure Completion**
+- [ ] **Complete Workshop Directory**
+  - Finish workshop documentation structure
+  - Create apprenticeship program materials
+  - Develop advanced architectural guides
+
+### **ADR-0017: Internal Review Protocol Enhancement**
+- [ ] **Protocol Refinement**
+  - Enhance High Council review automation
+  - Improve internal review processes
+  - Document architectural decision workflows
+
+---
+
+## 🏗️ **Phase 3: Production Readiness**
+**Timeline:** 3-4 weeks  
+**Priority:** MEDIUM - Operational excellence
+
+### **ADR-0002: Internal Release Management**
+- [ ] **Internal Release Pipeline**
+  - Automated version management
+  - Internal package distribution
+  - Release note generation for development
+
+### **ADR-0006: Release Process Automation**
+- [ ] **Five-Phase Release Implementation**
+  - Automate "Fivefold Release Breath" process
+  - Integrate with internal review processes
+  - Quality gate automation
+
+---
+
+## 🔮 **Phase 4: Future Enhancements**
+**Timeline:** Future consideration  
+**Priority:** LOW - Post-v1.0 features
+
+### **ADR-0015: Lamina-Aligned Model Training**
+- [ ] **Training Infrastructure**
+  - RAG implementation for corpus
+  - Fine-tuning pipeline development
+  - Community model serving
+
+---
+
+## Dependencies and Blockers
+
+### **Critical Dependencies**
+1. **ADR-0019 Approval**: Agent architecture needs High Council formal approval
+2. **Security Review**: Final security audit before public release
+3. **Community Resources**: Documentation and support materials
+
+### **No Current Blockers**
+- All technical implementation is complete
+- Infrastructure is production-ready
+- Core framework is operational
+
+---
+
+## Success Metrics
+
+### **Phase 1 Completion (v1.0.0 Core Features)**
+- [ ] A-MEM hierarchical memory system operational
+- [ ] Core chat loop with memory integration functional
+- [ ] Multi-agent interaction experiments framework complete
+- [ ] Vow system with ethical constraint enforcement working
+- [ ] Room transition system with spatial context management
+- [ ] Agent-to-agent communication protocols established
+
+### **v1.0.0 Readiness Metrics**
+- [ ] Memory persistence across agent sessions working
+- [ ] Multi-turn conversations with context preservation
+- [ ] Ethical constraints enforced in real-time during interactions
+- [ ] Agent spatial awareness and room transitions functional
+- [ ] Agent coordination and collaboration capabilities
+- [ ] Experiment framework for complex multi-agent scenarios
+
+### **Framework Maturity**
+- [ ] All ADRs in ACCEPTED status
+- [ ] Comprehensive test coverage maintained
+- [ ] Internal deployment procedures documented
+- [ ] Development best practices established
+
+---
+
+## Risk Assessment
+
+### **Low Risk Areas**
+- **Technical Implementation**: All core systems operational
+- **Infrastructure**: Production-ready deployment architecture
+- **Governance**: Well-established processes and oversight
+
+### **Medium Risk Areas**
+- **Framework Complexity**: Increasing complexity as features are added
+- **Documentation Debt**: Keeping documentation current with rapid development
+- **Integration Challenges**: Ensuring smooth interaction between packages
+
+### **Mitigation Strategies**
+- Regular architectural reviews to manage complexity
+- Continuous documentation updates with development
+- Comprehensive integration testing and validation
+
+---
+
+## Resource Requirements
+
+### **Development Effort**
+- **Phase 1**: 150-200 hours (Complete v1.0.0 feature implementation)
+  - A-MEM Integration: 30-40 hours
+  - Core Chat Loop: 25-35 hours  
+  - Multi-Agent Experiments: 25-35 hours
+  - Vow System Implementation: 35-45 hours
+  - Room Transition System: 25-35 hours
+  - Integration & Testing: 30-40 hours
+- **Phase 2**: 30-40 hours (developer experience improvements, documentation)
+- **Phase 3**: 20-30 hours (internal automation and release processes)
+
+### **Internal Resources**
+- Technical documentation review and validation
+- Framework testing and integration validation
+- Architectural review and refinement
+
+---
+
+## Conclusion
+
+Lamina OS has established a solid foundation with enterprise-grade infrastructure and agent architecture, but **significant development work remains to achieve v1.0.0 readiness**. The roadmap reflects the ambitious scope of implementing a complete presence-aware AI system with persistent memory, ethical constraints, spatial awareness, and sophisticated multi-agent coordination.
+
+The **150-200 hour development effort** for Phase 1 represents substantial work to implement:
+- **A-MEM**: Hierarchical memory system with persistence and context-aware retrieval
+- **Chat Loop**: Integrated conversation management with memory and model coordination  
+- **Multi-Agent Experiments**: Framework for complex agent-to-agent interaction scenarios
+- **Vow System**: Real-time ethical constraint enforcement and violation detection
+- **Room Transitions**: Spatial context management and multi-room agent coordination
+
+This comprehensive feature set will transform Lamina OS from an architectural foundation into a fully functional presence-aware AI development platform ready for v1.0.0 release.
+
+*This roadmap reflects the conscious intention to mature Lamina OS toward v1.0.0 readiness while maintaining the philosophical integrity and technical excellence that define the framework.*
+
+---
+
+**Next Steps:**
+1. Review and approve this roadmap
+2. Begin Phase 1 framework development
+3. Coordinate High Council review of pending ADRs
+4. Focus on internal capabilities and documentation enhancement

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,81 @@
+# Lamina OS
+
+**A breath-first AI development framework**
+
+---
+
+Lamina OS is a presence-aware AI development framework that prioritizes ethical, mindful, and technically sophisticated approaches to building AI systems. Built on breath-first principles, it provides the foundation for creating AI agents that operate with deliberate intention and embedded ethical constraints.
+
+## 🌟 Key Features
+
+### **Agent Architecture Foundation**
+- **Essence-based Configuration**: Agents defined through sanctuary markdown files capturing behavioral characteristics
+- **Breath-first Operation**: Mandatory deliberate pauses and conscious processing patterns
+- **Constraint Enforcement**: Built-in vow system for ethical boundary maintenance
+
+### **Production-Ready Infrastructure** 
+- **Enterprise Service Mesh**: Kubernetes deployment with Istio and strict mTLS
+- **Comprehensive Observability**: Prometheus, Grafana, Jaeger, and Kiali integration
+- **Multi-Environment Support**: Development to production scaling with AI model optimization
+
+### **Developer Experience**
+- **Unified CLI**: Three-tier command structure from development to specialized services
+- **Automated Deployment**: Idempotent setup and teardown for local Kubernetes clusters
+- **Comprehensive Testing**: Real AI model integration testing with containerized CI/CD
+
+## 🎯 Current Status
+
+Lamina OS has achieved exceptional architectural maturity with enterprise-grade infrastructure and comprehensive agent foundations. The framework is progressing toward **v1.0.0** with significant feature development planned:
+
+### **v1.0.0 Target Features**
+- **A-MEM**: Hierarchical agentic memory with persistence
+- **Core Chat Loop**: Integrated conversation management  
+- **Multi-Agent Experiments**: Framework for agent-to-agent interactions
+- **Vow System**: Real-time ethical constraint enforcement
+- **Room Transitions**: Spatial context management
+
+*See our [Roadmap](ROADMAP.md) for detailed development plans.*
+
+## 🏛️ Governance
+
+Lamina OS follows a structured governance model with:
+- **High Council**: Philosophical and architectural oversight
+- **ADR Process**: Formal architecture decision records
+- **Luthier Workshop**: Technical implementation and craftsmanship
+
+All decisions prioritize breath-first development principles and maintain clear boundaries between the public framework and private implementations.
+
+## 🚀 Quick Start
+
+1. **Explore the Architecture**
+   - Read our [Architecture Vision](technical/architecture-vision.md)
+   - Understand the [Philosophy](philosophy/philosophy.md)
+
+2. **Get Started Developing**  
+   - Follow the [Getting Started Guide](guides/getting-started.md)
+   - Review [Development Workflows](guides/github-workflow-guide.md)
+
+3. **Deploy Infrastructure**
+   - See [Infrastructure Documentation](technical/environments/README.md)
+   - Try the Kubernetes deployment examples
+
+## 📚 Documentation Structure
+
+- **[Guides](guides/getting-started.md)** - How-to guides and workflows
+- **[Architecture](technical/architecture-vision.md)** - Technical design and vision  
+- **[Philosophy](philosophy/philosophy.md)** - Foundational principles and concepts
+- **[Governance](adrs/README.md)** - ADRs, High Council reports, and decision processes
+- **[Releases](releases/v0.2.0/RELEASE_NOTES_v0.2.0.md)** - Version history and release notes
+
+## 🤝 Contributing
+
+Lamina OS is developed with conscious intention and breath-first practices. Contributors are encouraged to:
+
+- Understand the [philosophical foundations](philosophy/philosophy.md)
+- Follow [development workflows](guides/github-workflow-guide.md)  
+- Respect the [governance processes](adrs/README.md)
+- Maintain alignment with breath-first principles
+
+---
+
+*Lamina OS represents the conscious intention to provide infrastructure that embeds breath-first principles at the operational level, ensuring that development environments support rather than compromise the creation of presence-aware AI systems.*

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,10 @@
 
 **A breath-first AI development framework**
 
+> ⚠️ **PRE-ALPHA SOFTWARE WARNING**
+> 
+> Lamina OS is currently in pre-alpha development and is NOT suitable for production use. The framework is under active development with rapidly changing APIs, incomplete features, and potential security vulnerabilities. Use for research, experimentation, and development only. Do not deploy in production environments or use with sensitive data.
+
 ---
 
 Lamina OS is a presence-aware AI development framework that prioritizes ethical, mindful, and technically sophisticated approaches to building AI systems. Built on breath-first principles, it provides the foundation for creating AI agents that operate with deliberate intention and embedded ethical constraints.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,91 @@
+site_name: Lamina OS Documentation
+site_description: A breath-first AI development framework
+site_url: https://benaskins.github.io/lamina-os/
+repo_url: https://github.com/benaskins/lamina-os
+repo_name: benaskins/lamina-os
+
+theme:
+  name: material
+  palette:
+    # Palette toggle for light mode
+    - scheme: default
+      primary: deep purple
+      accent: purple
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    # Palette toggle for dark mode
+    - scheme: slate
+      primary: deep purple
+      accent: purple
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.path
+    - navigation.top
+    - search.highlight
+    - search.share
+    - toc.follow
+    - content.code.copy
+
+plugins:
+  - search
+  - awesome-pages
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started: 
+    - Overview: guides/getting-started.md
+    - Current Capabilities: technical/current-capabilities.md
+  - Architecture:
+    - Overview: technical/architecture-vision.md
+    - Environment Management: technical/environments/README.md
+  - Guides:
+    - Development Workflow: guides/github-workflow-guide.md
+    - AI Assistant Usage: guides/AI_ASSISTANT_USAGE.md
+    - Git Attribution: guides/luthier-git-attribution-guide.md
+    - CI Verification: guides/CI_VERIFICATION_PROTOCOL.md
+  - Philosophy:
+    - Core Principles: philosophy/philosophy.md
+    - Luthier Philosophy: philosophy/luthier-philosophy.md
+    - Framework vs Implementation: philosophy/framework-vs-implementation.md
+    - Sigil Script Grimoire: philosophy/sigil-script-grimoire.md
+    - Luthier Workshop: philosophy/luthier/workshop-guide.md
+  - Technical Reference:
+    - Dependencies: technical/UV_DEPENDENCY_ANALYSIS.md
+    - Security: technical/SECRETS_INVENTORY.md
+  - Governance:
+    - ADRs: adrs/README.md
+    - High Council Reports: 
+      - Technical Report 2025-01-06: high-council/HIGH_COUNCIL_TECHNICAL_REPORT_2025-01-06.md
+      - Terminology Review: high-council/HIGH_COUNCIL_CONSCIOUSNESS_TERMINOLOGY_REVIEW.md
+      - Lore Adaptations: high-council/LORE_ADAPTATIONS.md
+    - PIR: pir/PIR-2025-01-06-ruff-linting-failures.md
+  - Releases:
+    - Roadmap: ROADMAP.md
+    - v0.2.0: releases/v0.2.0/RELEASE_NOTES_v0.2.0.md
+    - v0.1.0: releases/v0.1.0/RELEASE_NOTES_v0.1.0.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/benaskins/lamina-os

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,3 @@
+mkdocs>=1.5.0
+mkdocs-material>=9.4.0
+mkdocs-awesome-pages-plugin>=2.9.0


### PR DESCRIPTION
## Summary
- Set up GitHub Pages documentation site using MkDocs with Material theme
- Added automatic deployment workflow for docs updates
- Created comprehensive navigation structure linking to reorganized documentation

## Changes
- `mkdocs.yml` - MkDocs configuration with Material theme and navigation
- `docs/index.md` - Documentation homepage highlighting current status and v1.0.0 roadmap
- `.github/workflows/docs.yml` - Automatic deployment on docs changes
- `requirements-docs.txt` - MkDocs dependencies
- `docs/.pages` - Navigation organization

## Next Steps
1. Merge this PR to main
2. Enable GitHub Pages in repository settings (Settings → Pages → GitHub Actions)
3. Documentation will be available at: https://benaskins.github.io/lamina-os/

🤖 Generated with [Claude Code](https://claude.ai/code)